### PR TITLE
Adjust FailedDelayedJobs alert

### DIFF
--- a/alerting/fb_platform.yml.erb
+++ b/alerting/fb_platform.yml.erb
@@ -49,7 +49,7 @@ spec:
         message: A failed Delayed job has occured in {{ $labels.namespace }}
         runbook_url: https://example.com/
       expr: |-
-        delta(delayed_jobs_failed{namespace="formbuilder-platform-<%= env_string %>"}[10m]) > 0
+        avg(delayed_jobs_failed{namespace="formbuilder-platform-<%= env_string %>"}) > 0
       for: 1m
       labels:
         severity: form-builder


### PR DESCRIPTION
Using the delta function over a 10 minute period means that Alert
Manager will send a message saying the issue has been resolved even
though there is still a failed submission in the queue.

Using avg instead of the delta should result in the resolved alert not
being sent until the number of failed submissions in the queue has
dropped back down to 0.