### PR TITLE
Identify failed delayed job environment

### DIFF
--- a/alerting/fb_platform.yml.erb
+++ b/alerting/fb_platform.yml.erb
@@ -46,7 +46,7 @@ spec:
         severity: form-builder
     - alert: FailedDelayedJobs
       annotations:
-        message: A failed Delayed job has occured in {{ $labels.namespace }}
+        message: A failed Delayed job has occured in <%= env_string %>
         runbook_url: https://example.com/
       expr: |-
         avg(delayed_jobs_failed{namespace="formbuilder-platform-<%= env_string %>"}) > 0


### PR DESCRIPTION
`label.namespace` is not outputted when the alert gets sent to Slack.
`env_string` is used in the alert manager so until the reason why the
label is not working correctly can be investigated use the `env_string`.