### PR TITLE
Send non prod alerts to low severity slack channel

### DIFF
--- a/alerting/fb_platform.yml.erb
+++ b/alerting/fb_platform.yml.erb
@@ -14,7 +14,7 @@ spec:
       expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"Running|Succeeded", namespace="formbuilder-platform-<%= env_string %>"}) > 0
       for: 2m
       labels:
-        severity: form-builder
+        severity: <%= severity %>
     - alert: KubePodCrashLooping
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively
@@ -22,7 +22,7 @@ spec:
       expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="formbuilder-platform-<%= env_string %>"}[10m]) * 60 * 10 > 1
       for: 5m
       labels:
-        severity: form-builder
+        severity: <%= severity %>
     - alert: KubeNamespaceQuotaNearing
       annotations:
         message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value }}% of its {{ $labels.resource }} quota.
@@ -34,7 +34,7 @@ spec:
           > 80
       for: 5m
       labels:
-        severity: form-builder
+        severity: <%= severity %>
     - alert: NamespaceMissing
       annotations:
         message: Namespace {{ $labels.namespace }} is missing
@@ -43,7 +43,7 @@ spec:
         absent(kube_namespace_created{namespace="formbuilder-platform-<%= env_string %>"})
       for: 1m
       labels:
-        severity: form-builder
+        severity: <%= severity %>
     - alert: FailedDelayedJobs
       annotations:
         message: A failed Delayed job has occured in <%= env_string %>
@@ -52,4 +52,4 @@ spec:
         avg(delayed_jobs_failed{namespace="formbuilder-platform-<%= env_string %>"}) > 0
       for: 1m
       labels:
-        severity: form-builder
+        severity: <%= severity %>

--- a/alerting/fb_publisher.yml.erb
+++ b/alerting/fb_publisher.yml.erb
@@ -14,7 +14,7 @@ spec:
       expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"Running", namespace="formbuilder-publisher-<%= platform_env %>"}) > 0
       for: 2m
       labels:
-        severity: form-builder
+        severity: <%= severity %>
     - alert: KubePodCrashLooping
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively
@@ -22,7 +22,7 @@ spec:
       expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="formbuilder-publisher-<%= platform_env %>"}[10m]) * 60 * 10 > 1
       for: 5m
       labels:
-        severity: form-builder
+        severity: <%= severity %>
     - alert: KubeNamespaceQuotaNearing
       annotations:
         message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value }}% of its {{ $labels.resource }} quota.
@@ -34,7 +34,7 @@ spec:
           > 80
       for: 5m
       labels:
-        severity: form-builder
+        severity: <%= severity %>
     - alert: NamespaceMissing
       annotations:
         message: Namespace {{ $labels.namespace }} is missing
@@ -43,7 +43,7 @@ spec:
         absent(kube_namespace_created{namespace="formbuilder-publisher-<%= platform_env %>"})
       for: 1m
       labels:
-        severity: form-builder
+        severity: <%= severity %>
     - alert: SlowResponses
       annotations:
         message: ingress {{ $labels.ingress }} is serving slow responses over 2 seconds
@@ -54,7 +54,7 @@ spec:
         rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace = "formbuilder-publisher-<%= platform_env %>"}[5m]) > 0) by (ingress) > 2
       for: 1m
       labels:
-        severity: form-builder
+        severity: <%= severity %>
     - alert: ClientErrorResponses
       annotations:
         message: ingress {{ $labels.ingress }} is serving 4XX responses
@@ -63,7 +63,7 @@ spec:
         avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="formbuilder-publisher-<%= platform_env %>", status=~"4.*"}[1m]) * 60 > 0) by (ingress)
       for: 1m
       labels:
-        severity: form-builder
+        severity: <%= severity %>
     - alert: ServerErrorResponses
       annotations:
         message: ingress {{ $labels.ingress }} is serving 5XX responses
@@ -72,4 +72,4 @@ spec:
         avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="formbuilder-publisher-<%= platform_env %>", status=~"5.*"}[1m]) * 60 > 0) by (ingress)
       for: 1m
       labels:
-        severity: form-builder
+        severity: <%= severity %>

--- a/alerting/fb_services.yml.erb
+++ b/alerting/fb_services.yml.erb
@@ -14,7 +14,7 @@ spec:
       expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"Running", namespace="formbuilder-services-<%= env_string %>"}) > 0
       for: 2m
       labels:
-        severity: form-builder
+        severity: <%= severity %>
     - alert: KubePodCrashLooping
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively
@@ -22,7 +22,7 @@ spec:
       expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="formbuilder-services-<%= env_string %>"}[10m]) * 60 * 10 > 1
       for: 5m
       labels:
-        severity: form-builder
+        severity: <%= severity %>
     - alert: KubeNamespaceQuotaNearing
       annotations:
         message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value }}% of its {{ $labels.resource }} quota.
@@ -34,7 +34,7 @@ spec:
           > 80
       for: 5m
       labels:
-        severity: form-builder
+        severity: <%= severity %>
     - alert: NamespaceMissing
       annotations:
         message: Namespace {{ $labels.namespace }} is missing
@@ -43,7 +43,7 @@ spec:
         absent(kube_namespace_created{namespace="formbuilder-services-<%= env_string %>"})
       for: 1m
       labels:
-        severity: form-builder
+        severity: <%= severity %>
     - alert: SlowResponses
       annotations:
         message: ingress {{ $labels.ingress }} in {{ $labels.exported_namespace }} is serving slow responses over 3 seconds
@@ -54,7 +54,7 @@ spec:
         rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace = "formbuilder-services-<%= env_string %>"}[5m]) > 0) by (ingress) > 3
       for: 5m
       labels:
-        severity: form-builder
+        severity: <%= severity %>
     - alert: ClientErrorResponses
       annotations:
         message: ingress {{ $labels.ingress }} in {{ $labels.namespace }} is serving 4XX responses
@@ -63,7 +63,7 @@ spec:
         avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="formbuilder-services-<%= env_string %>", status=~"4.*"}[1m]) * 60 > 0) by (ingress)
       for: 1m
       labels:
-        severity: form-builder
+        severity: <%= severity %>
     - alert: ServerErrorResponses
       annotations:
         message: ingress {{ $labels.ingress }} in {{ $labels.namespace }} is serving 5XX responses
@@ -72,4 +72,4 @@ spec:
         avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="formbuilder-services-<%= env_string %>", status=~"5.*"}[1m]) * 60 > 0) by (ingress)
       for: 1m
       labels:
-        severity: form-builder
+        severity: <%= severity %>

--- a/scripts/deploy_alerting.rb
+++ b/scripts/deploy_alerting.rb
@@ -8,6 +8,7 @@ alerts = { 'services' => 'alerting/fb_services.yml.erb',
 alert = alerts[ARGV[0]]
 platform_env = ARGV[1] # %w{ test live }
 deployment_env = ARGV[2] # %w{ dev production }
+severity = 'form-builder-low-severity'
 out_path = './out.yml'
 
 raise ArgumentError.new('Please provide namespace/alerts') if alert.nil?
@@ -18,6 +19,7 @@ FileUtils.rm(out_path, force: true)
 
 File.open(out_path, 'w') do |f|
   env_string = "#{platform_env}-#{deployment_env}"
+  severity = 'form-builder' if env_string == 'live-production'
   string = File.read(alert)
   template = ERB.new(string)
   f.write template.result(binding)


### PR DESCRIPTION
The #form-builder-alerts channel was a mixture of alerts from all 4environments. This generated a lot of noise.

A new slack channel, #form-builder-alerts-low-severity, was created to receive all non production alerts instead.

In [this ticket](https://github.com/ministryofjustice/cloud-platform/issues/1858) Cloud Platform created the necessary plumbing for these alerts to be sent to the correct channel.

`live-production` alerts should remain being sent to the #form-builder-alerts channel.

https://trello.com/c/Ifv0G0ph/348-high-and-low-severity-alerts-in-slack