### PR TITLE
Increase pod not ready time

### DIFF
--- a/alerting/fb_platform.yml.erb
+++ b/alerting/fb_platform.yml.erb
@@ -12,7 +12,7 @@ spec:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 2 minutes
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
       expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"Running|Succeeded", namespace="formbuilder-platform-<%= env_string %>"}) > 0
-      for: 2m
+      for: 3m
       labels:
         severity: <%= severity %>
     - alert: KubePodCrashLooping

--- a/alerting/fb_publisher.yml.erb
+++ b/alerting/fb_publisher.yml.erb
@@ -12,7 +12,7 @@ spec:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 2 minutes
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
       expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"Running", namespace="formbuilder-publisher-<%= platform_env %>"}) > 0
-      for: 2m
+      for: 3m
       labels:
         severity: <%= severity %>
     - alert: KubePodCrashLooping

--- a/alerting/fb_services.yml.erb
+++ b/alerting/fb_services.yml.erb
@@ -12,7 +12,7 @@ spec:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 2 minutes
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
       expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"Running", namespace="formbuilder-services-<%= env_string %>"}) > 0
-      for: 2m
+      for: 3m
       labels:
         severity: <%= severity %>
     - alert: KubePodCrashLooping


### PR DESCRIPTION
The `KubePodNotReady` alert triggers fairly frequently and by the time a developer goes to look at what is happening the pod in question has started up.

It is possible that 2 minutes is too short a time for a pod to become ready. Try raising it to 3 minutes.