### PR TITLE
Fix prometheus alert

### DIFF
--- a/alerting/fb_services.yml.erb
+++ b/alerting/fb_services.yml.erb
@@ -60,7 +60,7 @@ spec:
         message: ingress {{ $labels.ingress }} in {{ $labels.namespace }} is serving 4XX responses
         runbook_url: https://example.com/
       expr: |-
-        avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="formbuilder-services-<%= env_string %>", status=~"4.*"}[1m]) * 60 > 0) by (ingress)
+        avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="formbuilder-services-<%= env_string %>", status=~"4.*"}[1m]) * 60 >= 1) by (ingress)
       for: 1m
       labels:
         severity: form-builder


### PR DESCRIPTION
Prometheus was returning 40* requests which don't happen on our
logs/kibana. Increasing to 1 maybe removes the false positives.