### PR TITLE
Increase pod not ready timeout

### DIFF
--- a/alerting/fb_services.yml.erb
+++ b/alerting/fb_services.yml.erb
@@ -9,10 +9,10 @@ spec:
     rules:
     - alert: KubePodNotReady
       annotations:
-        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 3 minutes
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 6 minutes
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
       expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"Running", namespace="formbuilder-services-<%= env_string %>"}) > 0
-      for: 3m
+      for: 6m
       labels:
         severity: <%= severity %>
     - alert: KubePodCrashLooping


### PR DESCRIPTION
The pods for services frequently take over 5 minutes in order to become
ready. The alert is not helpful as there is still another pod running.

Preferably we should have a check for 0 pods running.