### PR TITLE
Add the alerts inside of cloud platform environment

### DIFF
--- a/alerting/fb_platform.yml.erb
+++ b/alerting/fb_platform.yml.erb
@@ -3,6 +3,8 @@ kind: PrometheusRule
 metadata:
   name: fb-alerting-platform-<%= env_string %>
   namespace: formbuilder-platform-<%= env_string %>
+  labels:
+    prometheus: cloud-platform
 spec:
   groups:
   - name: platform

--- a/alerting/fb_publisher.yml.erb
+++ b/alerting/fb_publisher.yml.erb
@@ -3,6 +3,8 @@ kind: PrometheusRule
 metadata:
   name: fb-alerting-publisher-<%= platform_env %>
   namespace: formbuilder-publisher-<%= platform_env %>
+  labels:
+    prometheus: cloud-platform
 spec:
   groups:
   - name: publisher

--- a/alerting/fb_services.yml.erb
+++ b/alerting/fb_services.yml.erb
@@ -3,6 +3,8 @@ kind: PrometheusRule
 metadata:
   name: fb-alerting-services-<%= env_string %>
   namespace: formbuilder-services-<%= env_string %>
+  labels:
+    prometheus: cloud-platform
 spec:
   groups:
   - name: forms


### PR DESCRIPTION
From the CP team:

"This is quite important because I am creating another Prometheus and
if you don't rename some of the alerts you might end up losing them.
As always, we recommend prometheusRules to be managed from the
environment repo, that way I would have been able to make that change
myself, directly."