### PR TITLE
 Do not trigger alerts for 401s

### DIFF
--- a/alerting/fb_services.yml.erb
+++ b/alerting/fb_services.yml.erb
@@ -62,7 +62,7 @@ spec:
         message: ingress {{ $labels.ingress }} in {{ $labels.namespace }} is serving 4XX responses
         runbook_url: https://example.com/
       expr: |-
-        avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="formbuilder-services-<%= env_string %>", status=~"4.*"}[1m]) * 60 >= 1) by (ingress)
+        avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="formbuilder-services-<%= env_string %>", status=~"400|403|404|499"}[1m]) * 60 >= 1) by (ingress)
       for: 1m
       labels:
         severity: <%= severity %>


### PR DESCRIPTION
The expression for 4xx errors will trigger if there is an average of 1 or more errors per ingress over a minute. It also alerts for 401s and since quite a lot of our forms have basic authentication in them that means that some automated tests will cause alerts every time they run.

[More info about basic authentication here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)

When basic authentication is set the server responds to the client with a 401 and requests a username and password. If the client sends those correctly then the server responds with a 200. If the wrong credentials are sent then the server will respond with a 403.

Therefore we do not really care about 401s as much as 403s. This is especially apparent as no live forms have a basic authentication, only forms in dev (preview).

Change the alert to be more specific. We are interested in 400, 403, 404 and 499 (nginx's own http response code for clients closing a connection).

https://trello.com/c/9gfX4Nt3/1133-reduce-the-noise-in-the-alerts-channel

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>