### PR TITLE
Increase platform KubePodNotReady alert threshold

### DIFF
--- a/alerting/fb_platform.yml.erb
+++ b/alerting/fb_platform.yml.erb
@@ -11,10 +11,10 @@ spec:
     rules:
     - alert: KubePodNotReady
       annotations:
-        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 3 minutes
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 6 minutes
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
       expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"Running|Succeeded", namespace="formbuilder-platform-<%= env_string %>"}) > 0
-      for: 3m
+      for: 6m
       labels:
         severity: <%= severity %>
     - alert: KubePodCrashLooping


### PR DESCRIPTION
3 minutes is a little too short for Kubernetes to complete creating a
  new container. The services namespaces have it set to 6 minutes. It
is reasonable to up the threshold for the platform to the same.