### PR TITLE
Increase KubePodNotReady time to 10 minutes

### DIFF
--- a/alerting/fb_hmcts_adapter.yml.erb
+++ b/alerting/fb_hmcts_adapter.yml.erb
@@ -11,10 +11,10 @@ spec:
     rules:
     - alert: KubePodNotReady
       annotations:
-        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 3 minutes
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 10 minutes
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
       expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"Running|Succeeded", namespace="hmcts-complaints-formbuilder-adapter-<%= env_string %>"}) > 0
-      for: 3m
+      for: 10m
       labels:
         severity: <%= severity %>
     - alert: KubePodCrashLooping

--- a/alerting/fb_platform.yml.erb
+++ b/alerting/fb_platform.yml.erb
@@ -11,10 +11,10 @@ spec:
     rules:
     - alert: KubePodNotReady
       annotations:
-        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 6 minutes
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 10 minutes
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
       expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"Running|Succeeded", namespace="formbuilder-platform-<%= env_string %>"}) > 0
-      for: 6m
+      for: 10m
       labels:
         severity: <%= severity %>
     - alert: KubePodCrashLooping

--- a/alerting/fb_publisher.yml.erb
+++ b/alerting/fb_publisher.yml.erb
@@ -11,10 +11,10 @@ spec:
     rules:
     - alert: KubePodNotReady
       annotations:
-        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 6 minutes
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 10 minutes
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
       expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"Running", namespace="formbuilder-publisher-<%= platform_env %>"}) > 0
-      for: 6m
+      for: 10m
       labels:
         severity: <%= severity %>
     - alert: KubePodCrashLooping

--- a/alerting/fb_services.yml.erb
+++ b/alerting/fb_services.yml.erb
@@ -11,10 +11,10 @@ spec:
     rules:
     - alert: KubePodNotReady
       annotations:
-        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 6 minutes
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) has been in a non-ready state for longer than 10 minutes
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
       expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"Running", namespace="formbuilder-services-<%= env_string %>"}) > 0
-      for: 6m
+      for: 10m
       labels:
         severity: <%= severity %>
     - alert: KubePodCrashLooping


### PR DESCRIPTION
The rollout of the pods sometimes takes a while. Since there are more
than one pod, fb-av aside, per app then it's fine for them to take that
long to be ready.