### PR TITLE
Add more scripts to the new eks cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           command: 'ruby scripts/deploy_alerting.rb platform test dev'
       - run:
           name: kubectl configure platform test production
-          command: 'scripts/circleci_configure_context.sh platform test production'
+          command: 'scripts/circleci_configure_context_eks.sh platform test production'
       - run:
           name: deploy platform alerting to platform test production
           command: 'ruby scripts/deploy_alerting.rb platform test production'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,51 @@
 version: 2
 jobs:
+  deploy_eks:
+    working_directory: ~/circle/
+    docker:
+      - image: $AWS_ECR_ACCOUNT_URL
+        aws_auth:
+            aws_access_key_id: $AWS_ACCESS_KEY_ID
+            aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+    steps:
+      - checkout
+      - run:
+          name: KUBE_CERTIFICATE_AUTHORITY to disk
+          command: 'echo -n "$EKS_CLUSTER_CERT" | base64 -d > /root/circle/.kube_certificate_authority'
+      - run:
+          name: kubectl configure cluster
+          command: 'kubectl config set-cluster "$EKS_CLUSTER" --certificate-authority="/root/circle/.kube_certificate_authority" --server="$EKS_SERVER"'
+      - run:
+          name: kubectl configure credentials
+          command: 'kubectl config set-credentials "circleci" --token="$(echo $EKS_TOKEN | base64 -d)"'
+      - run:
+          name: kubectl configure context
+          command: 'kubectl config set-context "circleci" --cluster="$EKS_CLUSTER" --user="circleci" --namespace="formbuilder-monitoring"'
+      - run:
+          name: kubectl use circleci context
+          command: 'kubectl config use-context "circleci"'
+      - run:
+          name: deploy grafana dashboard
+          command: 'kubectl apply -f fb_grafana_dashboard_config_map.yml'
+      # platform test
+      - run:
+          name: kubectl configure platform test dev
+          command: 'scripts/circleci_configure_context_eks.sh platform test dev'
+      - run:
+          name: deploy platform alerting to platform test dev
+          command: 'ruby scripts/deploy_alerting.rb platform test dev'
+      - run:
+          name: kubectl configure platform test production
+          command: 'scripts/circleci_configure_context.sh platform test production'
+      - run:
+          name: deploy platform alerting to platform test production
+          command: 'ruby scripts/deploy_alerting.rb platform test production'
+      - run:
+          name: kubectl configure publisher test
+          command: 'scripts/circleci_configure_context_eks.sh publisher test'
+      - run:
+          name: deploy publisher alerting to publisher test
+          command: 'ruby scripts/deploy_alerting.rb publisher test'
   deploy:
     working_directory: ~/circle/
     docker:
@@ -114,3 +160,9 @@ workflows:
           filters:
             branches:
               only: master
+      - deploy_eks:
+          filters:
+            branches:
+              only:
+                - master
+                - new-live-cluster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,12 @@ jobs:
       - run:
           name: deploy publisher alerting to publisher test
           command: 'ruby scripts/deploy_alerting.rb publisher test'
+      - run:
+          name: kubectl configure hmcts_complaints_adapter staging
+          command: 'scripts/circleci_configure_context_eks.sh hmcts_complaints_adapter staging'
+      - run:
+          name: deploy hmcts_complaints_adapter alerting to hmcts_complaints_adapter staging
+          command: 'ruby scripts/deploy_alerting.rb hmcts_complaints_adapter staging'
   deploy:
     working_directory: ~/circle/
     docker:
@@ -165,4 +171,3 @@ workflows:
             branches:
               only:
                 - master
-                - new-live-cluster

--- a/scripts/circleci_configure_context_eks.sh
+++ b/scripts/circleci_configure_context_eks.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+alert=$1
+platform_env=$2
+deployment_env=$3
+
+string="${alert}_${platform_env}_${deployment_env}"
+string=$(echo $string | awk '{ gsub(/_$/, ""); print }')
+
+upcase_string=$(echo $string | tr a-z A-Z)
+token=$(eval echo "\$EKS_${upcase_string}_TOKEN" | base64 -d)
+
+echo "kubectl configure credentials"
+kubectl config set-credentials "circleci_${string}" --token="${token}"
+
+echo "kubectl configure context"
+kubectl config set-context "circleci_${string}" --cluster="$EKS_CLUSTER" --user="circleci_${string}"
+
+echo "kubectl use circleci context"
+kubectl config use-context "circleci_${string}"


### PR DESCRIPTION
## Context

[Trello card](https://trello.com/c/5djc9UII/2103-migrate-monitoring-configuration-to-eks)

[CircleCI green status](https://app.circleci.com/pipelines/github/ministryofjustice/fb-monitoring/96/workflows/9e75d5ad-d877-4a20-81f2-05a114284b11/jobs/70):

This PR adds the new deployment script to the new EKS cluster.

## For future perspectives

All the tokens need to be encoded in CircleCI in order to pass.