### PR TITLE
Temporarily remove 404 alert for services

### DIFF
--- a/alerting/fb_services.yml.erb
+++ b/alerting/fb_services.yml.erb
@@ -62,7 +62,7 @@ spec:
         message: ingress {{ $labels.ingress }} in {{ $labels.namespace }} is serving 4XX responses
         runbook_url: https://example.com/
       expr: |-
-        avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="formbuilder-services-<%= env_string %>", status=~"400|403|404|499"}[1m]) * 60 >= 1) by (ingress)
+        avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="formbuilder-services-<%= env_string %>", status=~"400|403|499"}[1m]) * 60 >= 1) by (ingress)
       for: 1m
       labels:
         severity: <%= severity %>


### PR DESCRIPTION
We constantly get probed by bots trying to find endpoints to exploit. We
do need to monitor this in the long term but for now it is just
generating noise in the main alerts channel.