### PR TITLE
Remove NamespaceMissing alert

### DIFF
--- a/alerting/fb_hmcts_adapter.yml.erb
+++ b/alerting/fb_hmcts_adapter.yml.erb
@@ -37,15 +37,6 @@ spec:
       for: 5m
       labels:
         severity: <%= severity %>
-    - alert: NamespaceMissing
-      annotations:
-        message: Namespace {{ $labels.namespace }} is missing
-        runbook_url: https://example.com/
-      expr: |-
-        absent(kube_namespace_created{namespace="hmcts-complaints-formbuilder-adapter-<%= env_string %>"})
-      for: 1m
-      labels:
-        severity: <%= severity %>
     - alert: FailedDelayedJobs
       annotations:
         message: A failed Delayed job has occured in <%= env_string %>

--- a/alerting/fb_platform.yml.erb
+++ b/alerting/fb_platform.yml.erb
@@ -37,15 +37,6 @@ spec:
       for: 5m
       labels:
         severity: <%= severity %>
-    - alert: NamespaceMissing
-      annotations:
-        message: Namespace {{ $labels.namespace }} is missing
-        runbook_url: https://example.com/
-      expr: |-
-        absent(kube_namespace_created{namespace="formbuilder-platform-<%= env_string %>"})
-      for: 1m
-      labels:
-        severity: <%= severity %>
     - alert: FailedDelayedJobs
       annotations:
         message: A failed Delayed job has occured in <%= env_string %>

--- a/alerting/fb_publisher.yml.erb
+++ b/alerting/fb_publisher.yml.erb
@@ -37,15 +37,6 @@ spec:
       for: 5m
       labels:
         severity: <%= severity %>
-    - alert: NamespaceMissing
-      annotations:
-        message: Namespace {{ $labels.namespace }} is missing
-        runbook_url: https://example.com/
-      expr: |-
-        absent(kube_namespace_created{namespace="formbuilder-publisher-<%= platform_env %>"})
-      for: 1m
-      labels:
-        severity: <%= severity %>
     - alert: SlowResponses
       annotations:
         message: ingress {{ $labels.ingress }} is serving slow responses over 2 seconds

--- a/alerting/fb_services.yml.erb
+++ b/alerting/fb_services.yml.erb
@@ -37,15 +37,6 @@ spec:
       for: 5m
       labels:
         severity: <%= severity %>
-    - alert: NamespaceMissing
-      annotations:
-        message: Namespace {{ $labels.namespace }} is missing
-        runbook_url: https://example.com/
-      expr: |-
-        absent(kube_namespace_created{namespace="formbuilder-services-<%= env_string %>"})
-      for: 1m
-      labels:
-        severity: <%= severity %>
     - alert: SlowResponses
       annotations:
         message: ingress {{ $labels.ingress }} in {{ $labels.exported_namespace }} is serving slow responses over 3 seconds


### PR DESCRIPTION
This alert triggers for no discernable reason and is never actually
true.

If a namespace actually disappears then we will get a lot of other
alerts to let us know.