### PR TITLE
Configure specific severity for 4XX for services in live production

### DIFF
--- a/alerting/fb_services.yml.erb
+++ b/alerting/fb_services.yml.erb
@@ -53,7 +53,7 @@ spec:
         message: ingress {{ $labels.ingress }} in {{ $labels.namespace }} is serving 4XX responses
         runbook_url: https://example.com/
       expr: |-
-        avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="formbuilder-services-<%= env_string %>", status=~"400|403|499"}[1m]) * 60 >= 1) by (ingress)
+        avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace="formbuilder-services-<%= env_string %>", status=~"400|403|404|499"}[1m]) * 60 >= 1) by (ingress)
       for: 1m
       labels:
         severity: <%= severity %>

--- a/scripts/deploy_alerting.rb
+++ b/scripts/deploy_alerting.rb
@@ -9,7 +9,7 @@ alerts = {
 }
 
 alert = alerts[ARGV[0]]
-platform_env = ARGV[1] # %w{ test live staging production}
+platform_env = ARGV[1] # %w{ test live staging production }
 deployment_env = ARGV[2] # %w{ dev production }
 severity = 'form-builder-low-severity'
 out_path = './out.yml'
@@ -33,7 +33,11 @@ File.open(out_path, 'w') do |f|
   end
   puts "Environment string => #{env_string}"
 
-  severity = 'form-builder' if %w(live-production live production).include?(env_string)
+  if alert == 'services' && env_string == 'live-production'
+    severity = 'form-builder-400s' # 400s specific channel for live production only
+  elsif %w(live-production live production).include?(env_string)
+    severity = 'form-builder' # high severity alerts channel
+  end
   puts "Severity => #{severity}"
 
   string = File.read(alert)


### PR DESCRIPTION
We have created a specific slack channel to recieve 4XX alerts for
services running in live-production. Cloud Platform have set that up
using the severity called `form-builder-400s`.

Created here: https://github.com/ministryofjustice/cloud-platform/issues/3458

Put back the 404 alerts and make sure that the new severity is set
correctly for all the services in live-production.