### PR TITLE
Update default branch name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,9 +165,9 @@ workflows:
       - deploy:
           filters:
             branches:
-              only: master
+              only: main
       - deploy_eks:
           filters:
             branches:
               only:
-                - master
+                - main


### PR DESCRIPTION
Use `main` going forward. Have udpated the branch name in the Github UI.
Now just need CircleCI to use the correct branch.