### PR TITLE
Increase crashloop limit number for alerting

### DIFF
--- a/alerting/fb_hmcts_adapter.yml.erb
+++ b/alerting/fb_hmcts_adapter.yml.erb
@@ -21,7 +21,7 @@ spec:
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
-      expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="hmcts-complaints-formbuilder-adapter-<%= env_string %>"}[10m]) * 60 * 10 > 1
+      expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="hmcts-complaints-formbuilder-adapter-<%= env_string %>"}[10m]) * 60 * 10 > 3
       for: 5m
       labels:
         severity: <%= severity %>

--- a/alerting/fb_platform.yml.erb
+++ b/alerting/fb_platform.yml.erb
@@ -21,7 +21,7 @@ spec:
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
-      expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="formbuilder-platform-<%= env_string %>"}[10m]) * 60 * 10 > 1
+      expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="formbuilder-platform-<%= env_string %>"}[10m]) * 60 * 10 > 3
       for: 5m
       labels:
         severity: <%= severity %>

--- a/alerting/fb_publisher.yml.erb
+++ b/alerting/fb_publisher.yml.erb
@@ -21,7 +21,7 @@ spec:
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
-      expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="formbuilder-publisher-<%= platform_env %>"}[10m]) * 60 * 10 > 1
+      expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="formbuilder-publisher-<%= platform_env %>"}[10m]) * 60 * 10 > 3
       for: 5m
       labels:
         severity: <%= severity %>

--- a/alerting/fb_services.yml.erb
+++ b/alerting/fb_services.yml.erb
@@ -21,7 +21,7 @@ spec:
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
-      expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="formbuilder-services-<%= env_string %>"}[10m]) * 60 * 10 > 1
+      expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="formbuilder-services-<%= env_string %>"}[10m]) * 60 * 10 > 3
       for: 5m
       labels:
         severity: <%= severity %>


### PR DESCRIPTION
Pods in the cluster can restart for any number of reasons. We have multiple containers running and some of them restarting once or twice is not a big deal.

Increase to alert when there are 3 or more restarts over a 10 minute period